### PR TITLE
Tighten JSX prop types in Section.tsx

### DIFF
--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,12 +1,13 @@
 // src/components/Section.tsx
 // セクションラッパー: 上罫線 + ラベル + (任意) 右側リンク。
+import type { Child } from 'hono/jsx'
 import { safeUrl } from '../lib/url'
 
 type Props = {
   label: string
   sub?: string
-  right?: any
-  children: any
+  right?: Child
+  children: Child
 }
 
 export const Section = ({ label, sub, right, children }: Props) => {
@@ -29,6 +30,6 @@ export const Section = ({ label, sub, right, children }: Props) => {
 const linkHref = (href: string): string =>
   href.startsWith('/') && !href.startsWith('//') ? href : safeUrl(href)
 
-export const ViewAll = ({ href, children }: { href: string; children: any }) => (
+export const ViewAll = ({ href, children }: { href: string; children: Child }) => (
   <a class="view-all" href={linkHref(href)}>{children}</a>
 )


### PR DESCRIPTION
Closes #3.

Replace `right?: any` / `children: any` (Section + ViewAll) with `Child` from `hono/jsx`. No runtime change, just type safety at the section composition boundary.

`json: any` in `src/data/repos.ts` is intentionally left as-is — that's a parse boundary for an untrusted external response, which is the correct place for `any` until/unless we add a schema validator.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `/`, `/achievements`, `/career` all return 200 with the same rendered output