### PR TITLE
Career page: use company name as h2

### DIFF
--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -192,9 +192,17 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
 }
 .career-company {
   margin: 0;
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
+  letter-spacing: -0.01em;
   color: var(--fg);
+}
+.career-span {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--dim);
 }
 .career-role {
   margin: 4px 0 0;

--- a/src/components/CareerPage.tsx
+++ b/src/components/CareerPage.tsx
@@ -11,10 +11,10 @@ export const CareerPage = () => {
       {career.map((c) => (
         <section class="section">
           <div class="section-head">
-            <h2 class="label">{c.span}</h2>
+            <h2 class="career-company">{c.company}</h2>
+            <p class="career-span">{c.span}</p>
           </div>
           <div class="career-entry">
-            <p class="career-company">{c.company}</p>
             {c.role ? <p class="career-role">{c.role}</p> : null}
             {c.details && c.details.length ? (
               <ul class="career-list">


### PR DESCRIPTION
Closes #5.

`/career` now uses each company name as the section `<h2>` (the year span moves to a small uppercase sub-label). Improves screen-reader navigation — the heading list previously read as a sequence of bare year ranges.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `/career` returns 200 and the h2 elements now read company names (verified with grep)
- [x] Visual check: company name reads as a heading, year sits under it in the dim uppercase style