### PR TITLE
Rename .achievements CSS classes to a generic page namespace

### DIFF
--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -172,14 +172,14 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
 .row-co { color: var(--dim); }
 .tag { color: var(--dim); }
 
-/* ------ Achievements page ------ */
-.achievements-back {
+/* ------ Sub pages (Achievements / Career) ------ */
+.page-back {
   margin: 0 0 24px;
   font-size: 12px;
   color: var(--dim);
 }
-.achievements-back a { color: var(--dim); }
-.achievements-title {
+.page-back a { color: var(--dim); }
+.page-title {
   margin: 0 0 24px;
   font-size: 28px;
   font-weight: 600;

--- a/src/components/AchievementsPage.tsx
+++ b/src/components/AchievementsPage.tsx
@@ -14,9 +14,9 @@ export const AchievementsPage = () => {
   ]
 
   return (
-    <main class="achievements">
-      <p class="achievements-back"><a href="/">← Back to home</a></p>
-      <h1 class="achievements-title">Achievements</h1>
+    <main class="page">
+      <p class="page-back"><a href="/">← Back to home</a></p>
+      <h1 class="page-title">Achievements</h1>
 
       {cats.map((cat) => (
         <section class="section">

--- a/src/components/CareerPage.tsx
+++ b/src/components/CareerPage.tsx
@@ -4,9 +4,9 @@ import { career } from '../data/career'
 
 export const CareerPage = () => {
   return (
-    <main class="achievements">
-      <p class="achievements-back"><a href="/">← Back to home</a></p>
-      <h1 class="achievements-title">Career</h1>
+    <main class="page">
+      <p class="page-back"><a href="/">← Back to home</a></p>
+      <h1 class="page-title">Career</h1>
 
       {career.map((c) => (
         <section class="section">


### PR DESCRIPTION
Closes #4.

`.achievements` / `.achievements-back` / `.achievements-title` were defined for the Achievements page but reused by CareerPage. Rename them to `.page` / `.page-back` / `.page-title` so the chrome is honestly named for any sub-page.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All three routes return 200
- [x] No `.achievements*` selectors or class references remain (grep clean)
- [x] Visual check on `/achievements` and `/career` matches the previous look