### PR TITLE
Document the cache-layer choice per data source

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2,6 +2,13 @@
 // connpass 参加イベントを KV から読む(静的化)。
 // KV への書き込みは scheduled ハンドラ経由 (Cron Triggers)。
 // 取り込み元は connpass の公開ユーザーページ HTML (hCalendar / vevent)。
+//
+// なぜ KV (repos.ts / writing.ts は Cache API なのに):
+//   HTML スクレイピングは RSS/Atom より重く、 every-edge で取りに行くと
+//   connpass への負荷も応答時間も悪化する。一箇所(scheduled)で取って
+//   グローバルな KV に置けば、各エッジは KV を読むだけで済む。
+//   軽量な RSS/Atom (writing.ts) や API ピンポイント取得 (repos.ts) は
+//   per-edge Cache API で十分なので使い分けている。
 
 import { decodeEntities, toDateStr } from '../lib/feed'
 

--- a/src/data/repos.ts
+++ b/src/data/repos.ts
@@ -1,6 +1,10 @@
 // src/data/repos.ts
 // 看板OSSリポジトリ。Stars は GitHub API から動的に取得し、
 // Cloudflare Cache API で 24h キャッシュする。
+//
+// キャッシュ層の選定: GitHub API は軽量で、4 リポを並列に叩いても
+// 数百ms で済む。per-edge の Cache API で十分。グローバル一貫性が
+// 必要なら events.ts のように KV+Cron に寄せる(現状その必要なし)。
 
 export type Repo = {
   name: string

--- a/src/data/writing.ts
+++ b/src/data/writing.ts
@@ -3,6 +3,10 @@
 // - mizzy.org    : Atom フィードから動的取得 (1h キャッシュ)
 // - hateblo      : RSS フィードから動的取得 (1h キャッシュ)
 // - speakerdeck  : Atom フィードから動的取得 (1h キャッシュ)
+//
+// キャッシュ層の選定: RSS/Atom は軽量で取得失敗しても fallback がある。
+// per-edge の Cache API で十分。グローバル一貫性や定期 ingest が
+// 必要になったら events.ts のように KV+Cron に寄せる。
 
 import { decodeEntities, toDateStr } from '../lib/feed'
 


### PR DESCRIPTION
Closes #2.

Documents the deliberate Cache API vs KV+Cron split:

- `events.ts` uses **KV + hourly Cron** because HTML scraping is heavy and connpass-unfriendly to do per-edge; ingesting once and reading globally is the right shape.
- `repos.ts` (GitHub API) and `writing.ts` (RSS/Atom) use **per-edge Cache API** because the upstream is light, the data tolerates per-pop drift, and there's a fallback row on failure.

No code change — just rationale comments at the top of each file. The CLAUDE.md table covers the same ground but contributors editing one of these files will likely see the comment first.

If the cost/benefit shifts later (e.g. connpass moves to API in #1, GitHub rate-limits become noisy), revisit. For now this is the lightest correct documentation.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] No code change; runtime behavior identical