### PR TITLE
Remove Email row from Channels

### DIFF
--- a/src/components/ChannelsSection.tsx
+++ b/src/components/ChannelsSection.tsx
@@ -8,7 +8,6 @@ const accounts = [
   { kind: 'Speaker Deck', value: 'mizzy',                  url: 'https://speakerdeck.com/mizzy' },
   { kind: 'Blog',         value: 'mizzy.org',              url: 'https://mizzy.org/' },
   { kind: 'Hatena',       value: 'mizzy.hateblo.jp',       url: 'https://mizzy.hateblo.jp/' },
-  { kind: 'Email',        value: 'gosukenator@gmail.com',  url: 'mailto:gosukenator@gmail.com' },
 ]
 
 export const ChannelsSection = () => {


### PR DESCRIPTION
Drops the `mailto:` Email entry from the Channels section to reduce spam exposure. The remaining channels (GitHub, X, Speaker Deck, Blog, Hatena) cover contact paths sufficiently.

## Test plan

- [x] Channels section no longer shows Email