### PR TITLE
Address PageSpeed Insights findings (CSP / meta description / robots / sitemap)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://gosu.ke/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://gosu.ke/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://gosu.ke/achievements</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gosu.ke/career</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>

--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -3,8 +3,8 @@
 :root {
   --bg:     #eceef2;
   --fg:     #1a2230;
-  --dim:    #6c7589;
-  --rule:   #d8dde6;
+  --dim:    #535d72;   /* 旧 #6c7589 — WCAG AA 5.7:1 */
+  --rule:   #b8c0cf;   /* 旧 #d8dde6 — 罫線をライトモードで視認可能に */
   --accent: #2a4a8c;
   --link:   #2a4a8c;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,8 +29,11 @@ app.use('*', secureHeaders({
     styleSrc: ["'self'", 'https://fonts.googleapis.com'],
     fontSrc: ["'self'", 'https://fonts.gstatic.com'],
     imgSrc: ["'self'", 'data:'],
-    scriptSrc: ["'self'"],
-    connectSrc: ["'self'"],
+    // Cloudflare Insights の beacon (static.cloudflareinsights.com から)
+    // を許可。RUM 自体はゾーンで無効化済みだが、Cloudflare がページに
+    // beacon.min.js を自動注入するため CSP 側で許可しないとブロック警告が出る。
+    scriptSrc: ["'self'", 'https://static.cloudflareinsights.com'],
+    connectSrc: ["'self'", 'https://cloudflareinsights.com'],
     frameAncestors: ["'none'"],
     baseUri: ["'self'"],
     formAction: ["'self'"],
@@ -60,16 +63,36 @@ app.get('/', async (c) => {
   return c.html(layout(
     'Gosuke Miyashita',
     <HomePage repos={repos} mizzyOrg={mizzyOrg} hateblo={hateblo} speakerdeck={speakerdeck} events={events} />,
-    { path: '/' }
+    {
+      path: '/',
+      description:
+        'Gosuke Miyashita — freelance software engineer. OSS, talks, writing, and career.',
+    }
   ))
 })
 
 app.get('/achievements', (c) =>
-  c.html(layout('Achievements — Gosuke Miyashita', <AchievementsPage />, { path: '/achievements' }))
+  c.html(layout(
+    'Achievements — Gosuke Miyashita',
+    <AchievementsPage />,
+    {
+      path: '/achievements',
+      description:
+        'Awards, papers, books, articles, and talks by Gosuke Miyashita.',
+    }
+  ))
 )
 
 app.get('/career', (c) =>
-  c.html(layout('Career — Gosuke Miyashita', <CareerPage />, { path: '/career' }))
+  c.html(layout(
+    'Career — Gosuke Miyashita',
+    <CareerPage />,
+    {
+      path: '/career',
+      description:
+        'Career history of Gosuke Miyashita — from ITOCHU Techno-Science to paperboy&co. to freelance.',
+    }
+  ))
 )
 
 export default {

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -6,9 +6,12 @@ import { Footer } from './components/Footer'
 
 const SITE_URL = 'https://gosu.ke'
 const OG_IMAGE = `${SITE_URL}/static/images/profile.jpg`
+const DEFAULT_DESCRIPTION =
+  'Profile site of Gosuke Miyashita — freelance software engineer. OSS, talks, writing, and career.'
 
 type LayoutOptions = {
   path?: string  // canonical / og:url 用 (例: '/', '/achievements')
+  description?: string
 }
 
 export const layout = (
@@ -17,12 +20,14 @@ export const layout = (
   options: LayoutOptions = {}
 ) => {
   const url = `${SITE_URL}${options.path ?? '/'}`
+  const description = options.description ?? DEFAULT_DESCRIPTION
   return html`<!DOCTYPE html>
     <html lang="en">
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title>${title}</title>
+        <meta name="description" content="${description}" />
         <link rel="canonical" href="${url}" />
         <link rel="icon" type="image/jpeg" href="/static/images/favicon.jpg" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -30,6 +35,7 @@ export const layout = (
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
         <link rel="stylesheet" href="/static/css/style.css" />
         <meta property="og:title" content="${title}" />
+        <meta property="og:description" content="${description}" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="${url}" />
         <meta property="og:image" content="${OG_IMAGE}" />


### PR DESCRIPTION
Three findings from PageSpeed Insights mobile run:

1. **Best Practices: CSP blocked Cloudflare Insights beacon** — Cloudflare auto-injects `static.cloudflareinsights.com/beacon.min.js` even though the zone-level Web Analytics RUM is disabled. Allowing the script (and the beacon's `connect-src` target) closes the violation. RUM still reports nothing because the zone toggle is off.
2. **SEO: missing meta description** — `layout()` now takes an optional `description` and renders both `<meta name="description">` and `<meta property="og:description">`. Each route supplies a tailored sentence; a default is provided as a fallback.
3. **SEO: invalid robots.txt** — add `public/robots.txt` (allow all + sitemap reference) and `public/sitemap.xml` (the three indexable routes).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All routes carry a per-page meta description and og:description
- [x] `/robots.txt` and `/sitemap.xml` return 200
- [x] CSP header allows the Cloudflare Insights beacon