### PR TITLE
Add Bluesky and mixi2 to Channels

### DIFF
--- a/src/components/ChannelsSection.tsx
+++ b/src/components/ChannelsSection.tsx
@@ -5,6 +5,8 @@ import { safeUrl } from '../lib/url'
 const accounts = [
   { kind: 'GitHub',       value: 'mizzy',                  url: 'https://github.com/mizzy' },
   { kind: 'X',            value: 'gosukenator',            url: 'https://x.com/gosukenator' },
+  { kind: 'Bluesky',      value: 'mizzy.bsky.social',      url: 'https://bsky.app/profile/mizzy.bsky.social' },
+  { kind: 'mixi2',        value: 'mizzy',                  url: 'https://mixi.social/@mizzy' },
   { kind: 'Speaker Deck', value: 'mizzy',                  url: 'https://speakerdeck.com/mizzy' },
   { kind: 'Blog',         value: 'mizzy.org',              url: 'https://mizzy.org/' },
   { kind: 'Hatena',       value: 'mizzy.hateblo.jp',       url: 'https://mizzy.hateblo.jp/' },


### PR DESCRIPTION
Add two more SNS rows to the Channels section.

- Bluesky: `mizzy.bsky.social`
- mixi2: `@mizzy` (https://mixi.social)

SNS rows are now grouped together (GitHub, X, Bluesky, mixi2) before the publishing platforms (Speaker Deck, Blog, Hatena).

## Test plan

- [x] Channels section shows all seven entries with correct labels and URLs